### PR TITLE
Adding script to exon analysis and rename contigs to original version

### DIFF
--- a/annotation/nextflow/README.md
+++ b/annotation/nextflow/README.md
@@ -1,18 +1,25 @@
 # ANNOTATO - Annotation workflow To Annotate Them Oll
 
-## Prerequisites
+- [ANNOTATO - Annotation workflow To Annotate Them Oll](#annotato---annotation-workflow-to-annotate-them-oll)
+  - [Overview of the workflow](#overview-of-the-workflow)
+    - [Input data](#input-data)
+    - [Pipeline steps](#pipeline-steps)
+    - [Output data](#output-data)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+  - [Running ANNOTATO](#running-annotato)
+    - [Before running the pipeline (IMPORTANT)](#before-running-the-pipeline-important)
+    - [Without RNASeq and protein data](#without-rnaseq-and-protein-data)
+    - [Running ANNOTATO with RNASeq data](#running-annotato-with-rnaseq-data)
+    - [Running ANNOTATO with protein data](#running-annotato-with-protein-data)
+    - [Running ANNOTATO with both protein and RNASeq data](#running-annotato-with-both-protein-and-rnaseq-data)
+    - [Running ANNOTATO with params.json](#running-annotato-with-paramsjson)
+    - [Other parameters for running the analysis](#other-parameters-for-running-the-analysis)
+  - [Evaluating output GFF to the exon level](#evaluating-output-gff-to-the-exon-level)
+  - [Performance of the workflow on annotating difference eukaryote genomes](#performance-of-the-workflow-on-annotating-difference-eukaryote-genomes)
+  - [Future work](#future-work)
 
-The following programs are required to run the workflow and the listed version were tested. 
-
-`nextflow v23.04.0 or higher`
-
-`singularity`
-
-`conda` and `mamba` (currently, having problem with Funannotate and BRAKER installation)
-
-`docker` (have not been tested but in theory should work fine)
-
-## Workflow
+## Overview of the workflow
 
 The pipeline is based on `Funannotate` or `BRAKER` and was initially developed and tested on the two datasets:
 - Drosophila melanogaster: [https://doi.org/10.5281/zenodo.8013373](https://doi.org/10.5281/zenodo.8013373)
@@ -58,23 +65,29 @@ The main pipeline is divided into five different subworkflows.
 - Protein-coding gene annotation file in gff3 format
 - BUSCO summary of annotated sequences
 
-## Performance of the workflow on annotating difference eukaryote genomes
+## Prerequisites
 
-The following table is the result predicted by ANNOTATO on difference species during the [Europe BioHackathon 2023](https://github.com/elixir-europe/biohackathon-projects-2023/tree/main/20).
+The following programs are required to run the workflow and the listed version were tested. 
 
-| Species                    | Genome size | N.Genes | N.Exons | N.mRNA | BUSCO lineage | BUSCO score                             | OMArk Completeness                                                 | OMArk Consistency                                                                       |
-| :---:                      | :---:       | :---:   | :---:   | :---:  | :---:         | :---:                                   | :---:                                                              | :---:                                                                                   |
-| Drosophila melanogaster    | 143M        | 14,753  | 57,343  | 14,499 | diptera       | C:96.1%[S:95.6%,D:0.5%],F:1.2%,M:2.7%   | melanogaster subgroup, C:90.38%[S:84.32%,D:6.06%],M:9.62%,,n:12442 | A:94.21%[P:4.05%,F:7.28%],I:1.61%[P:0.5%,F:0.42%],C:0.00%[P:0.00%,F:0.00%],U:4.19%      |
-| Helleia helle              | 547M        | 37,367  | 139,302 | 28,445 | lepidoptera   | C:74.6%[S:73.4%,D:1.2%],F:5.4%,M:20.0%  | Papilionidea, C:82.04%[S:66.12%,D:15.92%],M:17.96%, n:7939         | A:44.78%[P:14.41%,F:6.02%],I:3.53%[P:2.1%,F:0.7%],C:0.00%[P:0.00%,F:0.00%],U:51.69%     |
-| Homo sapiens chrom 19      | 58M         | 1,872   | 11,937  | 1,862  | primates      | C:5.0%[S:4.8%,D:0.2%],F:0.5%,M:94.5%    | Hominidae, C:8.57%[S:7.74%,D:0.83%],M:91.43%, n=17843              | A:87.54%[P:12.73%,F:13.1%],I:4.78%[P:1.5%,F:2.04%],C:0.00%[P:0.00%,F:0.00%],U:7.68%     |
-| Melampus jaumei            | 958M        | 61,128  | 335,483 | 60,720 | mollusca      | C:80.4%[S:67.2%,D:13.2%],F:3.8%,M:15.8% | Lophotrochozoa, C: 92.5%[S: 66.29%, D: 26.21%], M:7.5%, n:2373     | A:41.45%[P:15.72%,F:9.97%],I:15.97%[P:10.68%,F:3.07%],C:0.00%[P:0.00%,F:0.00%],U:42.57% |
-| Phakellia ventilabrum      | 186M        | 19,073  | 157,441 | 18,855 | metazoa       | C:80.9%[S:79.2%,D:1.7%],F:6.5%,M:12.6%  | Metazoa, C:86.79%[S:76.9%,D:9.9%],M:13.21% , n:3021                | A:53.81%[P:18.92%,F:5.06%],I:5.0%[P:2.7%,F:0.68%],C:0.00%[P:0.00%,F:0.00%],U:41.19%     |
-| *Pocillopora* cf. *effusa* | 347M        | 35,103  | 230,901 | 33,086 | metazoa       | C:95.1%[S:92.2%,D:2.9%],F:1.7%,M:3.2%   | Eumetazoa, C:94.16%[S:84.3%,D:9.86%],M:5.84%,n:3255                | A:52.94%[P:22.30%,F:3.69%],I:3.44%[P:2.08%,F:0.28%],C:0.00%[P:0.00%,F:0.00%],U:43.62%   |
-| Trifolium dubium           | 679M        | 78,810  | 354,662 | 77,763 | fabales       | C:95.1%[S:19.5%,D:75.6%],F:1.5%,M:3.4%  | NPAAA clade, C:94.58%[S:19.21%,D:75.38%],M:5.42%,n:15412           | A:71.99%[P:11.03%,F:6.63%],I:2.77%[P:1.66%,F:0.52%],C:0.00%[P:0.00%,F:0.00%],U:25.23%   |
+`nextflow v23.04.0 or higher`
 
-## Running Annotato
+`singularity`
 
-### Before running the pipeline
+`conda` and `mamba` (currently, having problem with Funannotate and BRAKER installation)
+
+`docker` (have not been tested but in theory should work fine)
+
+## Installation
+
+Simply get the code from github or workflowhub and directly use it for the analysis with `nextflow`.
+
+```
+git clone https://github.com/ERGA-consortium/pipelines/tree/main/annotation/nextflow
+```
+
+## Running ANNOTATO
+
+### Before running the pipeline (IMPORTANT)
 
 One thing with Nextflow is that it is running off a Java Virtual Machine (JVM), and it will try to use all available memory for Nextflow even though it is unnecessary (for workflow management and job control). This will cause much trouble if you run a job on an HPC cluster. Thus, to minimize the effect of it, we need to limit the maximum memory the JVM can use.
 
@@ -96,7 +109,7 @@ nextflow run main.nf --genome /path/to/genome.fasta --species "Abc def" --buscod
 
 The workflow will run Denovo repeat masking on the draft genome, then softmask the repeat region and use the genome to run `funannotate`. Add `--run_braker` to run the genome prediction using `BRAKER` instead.
 
-### Running Annotato with RNASeq data
+### Running ANNOTATO with RNASeq data
 
 When you want to let the workflow run the mapping by itself, uses `input.csv` as input with the link to all `FASTQ` file.
 
@@ -114,7 +127,7 @@ nextflow run main.nf --genome /path/to/genome.fasta[.gz] --short_rna_bam /path/t
 
 **ATTENTION**: One major drawback of the current workflow is that the input genome will be sorted and renamed by the `funannotate sort` function. This is because `AUGUSTUS` and `Funannotate` won't work normally when the header of the input genome is too long and contains weird characters. Therefore, if you want to provide a `bam` file as input instead of the raw `FASTQ`, please run `funannotate sort` on the genome fasta first and then use it as the reference for running alignment. Or in case your genome headers are already shorter than 16 character, please add `--skip_rename` when running the pipeline.
 
-### Running Annotato with protein data
+### Running ANNOTATO with protein data
 
 ```
 nextflow run main.nf --genome /path/to/genome.fasta[.gz] --protein /path/to/protein.fasta[.gz] --species "Abc def" --buscodb 'metazoa' 
@@ -122,12 +135,20 @@ nextflow run main.nf --genome /path/to/genome.fasta[.gz] --protein /path/to/prot
 
 When only protein data is provided, the workflow will run denovo masking then repeat filter with the additional protein data. The masked genome and protein fasta will then be used for gene prediction.
 
-### Running Annotato with both protein and RNASeq data
+### Running ANNOTATO with both protein and RNASeq data
 
 The full pipeline is triggered when both RNASeq data and protein fasta is provided.
 
 ```
 nextflow run main.nf --genome /path/to/genome.fasta[.gz] --protein /path/to/protein.fasta[.gz] --rnaseq /path/to/input.csv --species "Abc def" --buscodb 'metazoa' 
+```
+
+### Running ANNOTATO with params.json
+
+One plus side with Nextflow is that it can use a parameter JSON file called `params.json` to start the analysis pipeline with all required parameters. Please modify the content of the `params.json` according to your need then run the following command.
+
+```
+nextflow run main.nf -params-file params.json
 ```
 
 ### Other parameters for running the analysis
@@ -193,6 +214,63 @@ Engines (choose one):
 
 Per default: -profile slurm,singularity is executed.
 ```
+
+## Evaluating output GFF to the exon level
+
+We provided a script to analyze the output GFF of ANNOTATO (which also could be applied to the GFF file output of other pipelines) to report the number of exons per mRNA/tRNA. To run this, simply use:
+
+```
+python bin/analyze_exons.py -f ${GFF}
+```
+
+Below is the sample output of this script
+
+```
+INFORMATION REGARDING mRNA
+Number of transcripts: 33086
+Largest number of exons in all transcripts: 128
+Monoexonic transcripts: 4085
+Multiexonic transcripts: 29001
+Mono:Mult Ratio: 0.14
+Boxplot of number of exons per transcript:
+Min: 1
+25%: 2
+50%: 4
+75%: 8
+Max: 128
+Mean: 6.978812790908542
+==================================================
+INFORMATION REGARDING tRNA
+Number of transcripts: 2017
+Largest number of exons in all transcripts: 1
+Monoexonic transcripts: 2017
+Multiexonic transcripts: 0
+No multiexonic transcripts, unable to calculate Mono:Mult Ratio
+Boxplot of number of exons per transcript:
+Min: 1
+25%: 1
+50%: 1
+75%: 1
+Max: 1
+Mean: 1.0
+==================================================
+```
+
+This script was originally written by [Katharina Hoff](https://github.com/Gaius-Augustus/GALBA/blob/main/scripts/analyze_exons.py) and was modified accordingly to suit the analysis of GFF file.
+
+## Performance of the workflow on annotating difference eukaryote genomes
+
+The following table is the result predicted by ANNOTATO on difference species during the [Europe BioHackathon 2023](https://github.com/elixir-europe/biohackathon-projects-2023/tree/main/20).
+
+| Species                    | Genome size | N.Genes | N.Exons | N.mRNA | BUSCO lineage | BUSCO score                             | OMArk Completeness                                                 | OMArk Consistency                                                                       |
+| :---:                      | :---:       | :---:   | :---:   | :---:  | :---:         | :---:                                   | :---:                                                              | :---:                                                                                   |
+| Drosophila melanogaster    | 143M        | 14,753  | 57,343  | 14,499 | diptera       | C:96.1%[S:95.6%,D:0.5%],F:1.2%,M:2.7%   | melanogaster subgroup, C:90.38%[S:84.32%,D:6.06%],M:9.62%,,n:12442 | A:94.21%[P:4.05%,F:7.28%],I:1.61%[P:0.5%,F:0.42%],C:0.00%[P:0.00%,F:0.00%],U:4.19%      |
+| Helleia helle              | 547M        | 37,367  | 139,302 | 28,445 | lepidoptera   | C:74.6%[S:73.4%,D:1.2%],F:5.4%,M:20.0%  | Papilionidea, C:82.04%[S:66.12%,D:15.92%],M:17.96%, n:7939         | A:44.78%[P:14.41%,F:6.02%],I:3.53%[P:2.1%,F:0.7%],C:0.00%[P:0.00%,F:0.00%],U:51.69%     |
+| Homo sapiens chrom 19      | 58M         | 1,872   | 11,937  | 1,862  | primates      | C:5.0%[S:4.8%,D:0.2%],F:0.5%,M:94.5%    | Hominidae, C:8.57%[S:7.74%,D:0.83%],M:91.43%, n=17843              | A:87.54%[P:12.73%,F:13.1%],I:4.78%[P:1.5%,F:2.04%],C:0.00%[P:0.00%,F:0.00%],U:7.68%     |
+| Melampus jaumei            | 958M        | 61,128  | 335,483 | 60,720 | mollusca      | C:80.4%[S:67.2%,D:13.2%],F:3.8%,M:15.8% | Lophotrochozoa, C: 92.5%[S: 66.29%, D: 26.21%], M:7.5%, n:2373     | A:41.45%[P:15.72%,F:9.97%],I:15.97%[P:10.68%,F:3.07%],C:0.00%[P:0.00%,F:0.00%],U:42.57% |
+| Phakellia ventilabrum      | 186M        | 19,073  | 157,441 | 18,855 | metazoa       | C:80.9%[S:79.2%,D:1.7%],F:6.5%,M:12.6%  | Metazoa, C:86.79%[S:76.9%,D:9.9%],M:13.21% , n:3021                | A:53.81%[P:18.92%,F:5.06%],I:5.0%[P:2.7%,F:0.68%],C:0.00%[P:0.00%,F:0.00%],U:41.19%     |
+| *Pocillopora* cf. *effusa* | 347M        | 35,103  | 230,901 | 33,086 | metazoa       | C:95.1%[S:92.2%,D:2.9%],F:1.7%,M:3.2%   | Eumetazoa, C:94.16%[S:84.3%,D:9.86%],M:5.84%,n:3255                | A:52.94%[P:22.30%,F:3.69%],I:3.44%[P:2.08%,F:0.28%],C:0.00%[P:0.00%,F:0.00%],U:43.62%   |
+| Trifolium dubium           | 679M        | 78,810  | 354,662 | 77,763 | fabales       | C:95.1%[S:19.5%,D:75.6%],F:1.5%,M:3.4%  | NPAAA clade, C:94.58%[S:19.21%,D:75.38%],M:5.42%,n:15412           | A:71.99%[P:11.03%,F:6.63%],I:2.77%[P:1.66%,F:0.52%],C:0.00%[P:0.00%,F:0.00%],U:25.23%   |
 
 ## Future work
 - Python wrapper function to remove intermediate files

--- a/annotation/nextflow/README.md
+++ b/annotation/nextflow/README.md
@@ -6,15 +6,25 @@ The following programs are required to run the workflow and the listed version w
 
 `nextflow v23.04.0 or higher`
 
-`conda` or `singularity`
+`singularity`
 
-`docker` (have not been tested)
+`conda` and `mamba` (currently, having problem with Funannotate and BRAKER installation)
+
+`docker` (have not been tested but in theory should work fine)
 
 ## Workflow
 
-The pipeline is based on `Funannotate` and/or `BRAKER` and was tested on these following datasets: 
+The pipeline is based on `Funannotate` or `BRAKER` and was initially developed and tested on the two datasets:
 - Drosophila melanogaster: [https://doi.org/10.5281/zenodo.8013373](https://doi.org/10.5281/zenodo.8013373)
-- Pocillopora meandrina
+- *Pocillopora* cf. *effusa*: [https://www.ncbi.nlm.nih.gov/biosample/26809107](https://www.ncbi.nlm.nih.gov/biosample/26809107)
+
+Then, it was further tested on these species during the [BioHackathon 2023 - project 20](https://github.com/elixir-europe/biohackathon-projects-2023/tree/main/20)
+
+- Helleia helle
+- Homo sapiens chrom 19
+- Melampus jaumei
+- Phakellia ventilabrum
+- Trifolium dubium
 
 ### Input data
 
@@ -47,6 +57,20 @@ The main pipeline is divided into five different subworkflows.
 - RepeatMasker report containing quantity of masked sequence and distribution among TE families
 - Protein-coding gene annotation file in gff3 format
 - BUSCO summary of annotated sequences
+
+## Performance of the workflow on annotating difference eukaryote genomes
+
+The following table is the result predicted by ANNOTATO on difference species during the [Europe BioHackathon 2023](https://github.com/elixir-europe/biohackathon-projects-2023/tree/main/20).
+
+| Species                    | Genome size | N.Genes | N.Exons | N.mRNA | BUSCO lineage | BUSCO score                             | OMArk Completeness                                                 | OMArk Consistency                                                                       |
+| :---:                      | :---:       | :---:   | :---:   | :---:  | :---:         | :---:                                   | :---:                                                              | :---:                                                                                   |
+| Drosophila melanogaster    | 143M        | 14,753  | 57,343  | 14,499 | diptera       | C:96.1%[S:95.6%,D:0.5%],F:1.2%,M:2.7%   | melanogaster subgroup, C:90.38%[S:84.32%,D:6.06%],M:9.62%,,n:12442 | A:94.21%[P:4.05%,F:7.28%],I:1.61%[P:0.5%,F:0.42%],C:0.00%[P:0.00%,F:0.00%],U:4.19%      |
+| Helleia helle              | 547M        | 37,367  | 139,302 | 28,445 | lepidoptera   | C:74.6%[S:73.4%,D:1.2%],F:5.4%,M:20.0%  | Papilionidea, C:82.04%[S:66.12%,D:15.92%],M:17.96%, n:7939         | A:44.78%[P:14.41%,F:6.02%],I:3.53%[P:2.1%,F:0.7%],C:0.00%[P:0.00%,F:0.00%],U:51.69%     |
+| Homo sapiens chrom 19      | 58M         | 1,872   | 11,937  | 1,862  | primates      | C:5.0%[S:4.8%,D:0.2%],F:0.5%,M:94.5%    | Hominidae, C:8.57%[S:7.74%,D:0.83%],M:91.43%, n=17843              | A:87.54%[P:12.73%,F:13.1%],I:4.78%[P:1.5%,F:2.04%],C:0.00%[P:0.00%,F:0.00%],U:7.68%     |
+| Melampus jaumei            | 958M        | 61,128  | 335,483 | 60,720 | mollusca      | C:80.4%[S:67.2%,D:13.2%],F:3.8%,M:15.8% | Lophotrochozoa, C: 92.5%[S: 66.29%, D: 26.21%], M:7.5%, n:2373     | A:41.45%[P:15.72%,F:9.97%],I:15.97%[P:10.68%,F:3.07%],C:0.00%[P:0.00%,F:0.00%],U:42.57% |
+| Phakellia ventilabrum      | 186M        | 19,073  | 157,441 | 18,855 | metazoa       | C:80.9%[S:79.2%,D:1.7%],F:6.5%,M:12.6%  | Metazoa, C:86.79%[S:76.9%,D:9.9%],M:13.21% , n:3021                | A:53.81%[P:18.92%,F:5.06%],I:5.0%[P:2.7%,F:0.68%],C:0.00%[P:0.00%,F:0.00%],U:41.19%     |
+| *Pocillopora* cf. *effusa* | 347M        | 35,103  | 230,901 | 33,086 | metazoa       | C:95.1%[S:92.2%,D:2.9%],F:1.7%,M:3.2%   | Eumetazoa, C:94.16%[S:84.3%,D:9.86%],M:5.84%,n:3255                | A:52.94%[P:22.30%,F:3.69%],I:3.44%[P:2.08%,F:0.28%],C:0.00%[P:0.00%,F:0.00%],U:43.62%   |
+| Trifolium dubium           | 679M        | 78,810  | 354,662 | 77,763 | fabales       | C:95.1%[S:19.5%,D:75.6%],F:1.5%,M:3.4%  | NPAAA clade, C:94.58%[S:19.21%,D:75.38%],M:5.42%,n:15412           | A:71.99%[P:11.03%,F:6.63%],I:2.77%[P:1.66%,F:0.52%],C:0.00%[P:0.00%,F:0.00%],U:25.23%   |
 
 ## Running Annotato
 
@@ -142,6 +166,9 @@ Funannotate params:
 --buscodb                      BUSCO database used for AUGUSTUS training and evaluation. [default: eukaryota]
 --buscoseed                    AUGUSTUS pre-trained species to start BUSCO. Will be override if rnaseq data is provided. [default: null]
 
+Braker params:
+--run_braker                   Whether to use BRAKER for gene prediction. [default: false]
+
 Skipping options:
 --skip_rename                  Skip renaming genome fasta file by funannotate sort. 
 --skip_all_masking             Skip all masking processes, please be sure that your --genome input is soft-masked before triggering this 
@@ -168,4 +195,7 @@ Per default: -profile slurm,singularity is executed.
 ```
 
 ## Future work
+- Python wrapper function to remove intermediate files
 - Adding functional annotation with `Interproscan` and `eggnog`
+- Adding PASA results to further improve the accuracy of the training
+- Adding custom parameter for both `BRAKER` and `funannotate`

--- a/annotation/nextflow/bin/analyze_exons.py
+++ b/annotation/nextflow/bin/analyze_exons.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+import re
+
+parser = argparse.ArgumentParser(
+    description='Analyse gff output file for ANNOTATO with respect of the number of exons per mRNA')
+parser.add_argument('-f', '--gff_file', type=str, required=True,
+                    help="Input gff file")
+args = parser.parse_args()
+
+# read gff file into a dictionary that has transcript name as key and number of exons as value
+mRNA_dict = {}
+tRNA_dict = {}
+try:
+    with open(args.gff_file, "r") as gff_file:
+        for line in gff_file:
+            if re.search(r'\tmRNA\t', line):
+                if re.search(r'ID=([^;]+)', line).group(1) not in mRNA_dict:
+                    mRNA_dict[re.search(r'ID=([^;]+)', line).group(1)] = 0
+            if re.search(r'\ttRNA\t', line):
+                if re.search(r'ID=([^;]+)', line).group(1) not in tRNA_dict:
+                    tRNA_dict[re.search(r'ID=([^;]+)', line).group(1)] = 0
+            if re.search(r'exon', line):
+                key = re.search(r'ID=([^;]+)', line).group(1).split(".exon")[0]
+                if key in mRNA_dict:
+                    mRNA_dict[key] += 1
+                else:
+                    tRNA_dict[key] += 1
+except IOError:
+    print("Could not read file:", args.gff_file)
+    sys.exit(1)
+
+# output some information about the dictionary
+reports = [mRNA_dict]
+if len(tRNA_dict) > 0:
+    reports.append(tRNA_dict)
+
+for info_dict in reports:
+    if info_dict == mRNA_dict:
+        print("INFORMATION REGARDING mRNA")
+    else:
+        print("INFORMATION REGARDING tRNA")
+    print("Number of transcripts:", len(info_dict))
+    print("Largest number of exons in all transcripts:", max(info_dict.values()))
+    print("Monoexonic transcripts:", list(info_dict.values()).count(1))
+    print("Multiexonic transcripts:", len(info_dict) - list(info_dict.values()).count(1))
+    if (len(info_dict) - list(info_dict.values()).count(1)) == 0:
+        print("No multiexonic transcripts, unable to calculate Mono:Mult Ratio")
+    else:
+        print("Mono:Mult Ratio:", round(list(info_dict.values()).count(1) / (len(info_dict) - list(info_dict.values()).count(1)), 2))
+
+    # print an ASCII boxplot of data in tx_dict
+    # get the largest number of exons in all transcripts
+    max_exons = max(info_dict.values())
+    # get the smallest number of exons in all transcripts
+    min_exons = min(info_dict.values())
+    # get the 25% quartile of values in tx_dict
+    q25 = sorted(info_dict.values())[int(len(info_dict) * 0.25)]
+    # get the 50% quartile of values in tx_dict
+    q50 = sorted(info_dict.values())[int(len(info_dict) * 0.5)]
+    # get the 75% quartile of values in tx_dict
+    q75 = sorted(info_dict.values())[int(len(info_dict) * 0.75)]
+
+
+    # print the boxplot
+    print("Boxplot of number of exons per transcript:")
+    print("Min:", min_exons)
+    print("25%:", q25)
+    print("50%:", q50)
+    print("75%:", q75)
+    print("Max:", max_exons)
+    print("Mean:", sum(info_dict.values())/len(info_dict))
+    print("="*50)

--- a/annotation/nextflow/bin/rename_gff.py
+++ b/annotation/nextflow/bin/rename_gff.py
@@ -1,0 +1,17 @@
+import os
+import argparse
+import pandas as pd
+
+def main(lookupTab, inputGff, outputGff):
+    df_lookup = pd.read_csv(lookupTab, sep = "\t", names=["original", "scaffold"])
+    df_inGff = pd.read_csv(inputGff, sep = "\t", names=["scaffold", "tool", "type", "start", "end", "score", "strand", "phase", "attributes"])
+    df_merged = df_inGff.merge(df_lookup, on="scaffold")[["original", "tool", "type", "start", "end", "score", "strand", "phase", "attributes"]]
+    df_merged.to_csv(outputGff, sep="\t", header=False, index=False)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Rename gff file contig back to the original one")
+    parser.add_argument("-l", "--lookup", help="Lookup table for converting contig name")
+    parser.add_argument("-i", "--inGff", help="Gff file to be converted")
+    parser.add_argument("-o", "--outGff", help="Name of the output Gff file")
+    args = parser.parse_args()
+    main(os.path.abspath(args.lookup), os.path.abspath(args.inGff), os.path.abspath(args.outGff))

--- a/annotation/nextflow/conf/conda.config
+++ b/annotation/nextflow/conf/conda.config
@@ -12,6 +12,7 @@ process {
     withLabel: blast         { conda = "$baseDir/envs/conda/blast.yml" }
     withLabel: busco         { conda = "$baseDir/envs/conda/busco.yml" }
     withLabel: fastp         { conda = "$baseDir/envs/conda/fastp.yml" }
+    withLabel: tools         { conda = "$baseDir/envs/conda/tools.yml" }
     withLabel: star          { conda = "$baseDir/envs/conda/star.yml" }
     withLabel: gaas          { conda = "$baseDir/envs/conda/gaas.yml" }
     withLabel: unix          { conda = "$baseDir/envs/conda/unix.yml" }   

--- a/annotation/nextflow/conf/container.config
+++ b/annotation/nextflow/conf/container.config
@@ -12,6 +12,7 @@ process {
     withLabel: blast         { container = "ncbi/blast:2.7.1" }
     withLabel: busco         { container = "quay.io/biocontainers/busco:5.5.0--pyhdfd78af_0" }
     withLabel: fastp         { container = "quay.io/biocontainers/fastp:0.23.4--hadf994f_2" }
+    withLabel: tools         { container = "amancevice/pandas:slim-2.1.3" }
     withLabel: star          { container = "quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0" }
     withLabel: gaas          { container = "phuongdoan96/gaas:1.2.0" }
 }

--- a/annotation/nextflow/conf/container.config
+++ b/annotation/nextflow/conf/container.config
@@ -12,7 +12,7 @@ process {
     withLabel: blast         { container = "ncbi/blast:2.7.1" }
     withLabel: busco         { container = "quay.io/biocontainers/busco:5.5.0--pyhdfd78af_0" }
     withLabel: fastp         { container = "quay.io/biocontainers/fastp:0.23.4--hadf994f_2" }
-    withLabel: tools         { container = "amancevice/pandas:slim-2.1.3" }
+    withLabel: tools         { container = "amancevice/pandas:2.1.3" }
     withLabel: star          { container = "quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0" }
     withLabel: gaas          { container = "phuongdoan96/gaas:1.2.0" }
 }

--- a/annotation/nextflow/conf/modules.config
+++ b/annotation/nextflow/conf/modules.config
@@ -187,6 +187,14 @@ process {
 		]
 	}
 
+	withName: RENAMEGFF {
+		publishDir = [
+			path: { "${params.outdir}/04.Gene_predict/"},
+			mode: params.publish_dir_mode,
+			saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+		]
+	}
+
 	withName: MULTIQC {
 		publishDir = [
 			path: { "${params.outdir}/multiqc"},

--- a/annotation/nextflow/envs/conda/funannotate.yml
+++ b/annotation/nextflow/envs/conda/funannotate.yml
@@ -1,5 +1,6 @@
 name: funannotate
 channels:
   - bioconda
+  - conda-forge
 dependencies:
   - funannotate=1.8.15

--- a/annotation/nextflow/envs/conda/tools.yml
+++ b/annotation/nextflow/envs/conda/tools.yml
@@ -1,0 +1,6 @@
+name: unix
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - pandas=2.1.3

--- a/annotation/nextflow/main.nf
+++ b/annotation/nextflow/main.nf
@@ -31,17 +31,17 @@ if (workflow.profile.contains('standard') || workflow.profile.contains('local'))
     println " "
 }
 
-def folder = new File(params.outdir)
-if ( folder.exists() ) { 
+def outdir = new File(params.outdir)
+if ( outdir.exists() ) { 
     println ""
-    println "\033[0;33mWARNING: Output folder exists. Results will be overwritten, you can adjust the output folder using [--output]\033[0m\n"
+    println "\033[0;33mWARNING: Output folder exists. Results will be overwritten, you can adjust the output folder using [--outdir]\033[0m\n"
 }
 
-def checkTmp = file(params.tmpdir)
+def checkTmp = new File(params.tmpdir)
 if ( !checkTmp.exists() ) {
-  exit 0
   println ""
-  println "\033[0;33mWARNING: ${params.tmpdir} does not exists, please create it.\033[0m\n"
+  println "\033[0;33mWARNING: ${params.tmpdir} does not exists, creating it.\033[0m\n"
+  checkTmp.mkdirs()
 }
 
 /*
@@ -49,6 +49,7 @@ if ( !checkTmp.exists() ) {
 */
 
 workflow {
+  println "START THE ANALYSIS\n"
 	ANNOTATO()
 }
 

--- a/annotation/nextflow/main.nf
+++ b/annotation/nextflow/main.nf
@@ -95,6 +95,9 @@ def helpMSG() {
     ${c_dim}--buscodb${c_reset}                   BUSCO database used for AUGUSTUS training and evaluation. [default: $params.buscodb]
     ${c_dim}--buscoseed${c_reset}                 AUGUSTUS pre-trained species to start BUSCO. Will be override if rnaseq data is provided. [default: $params.buscoseed]
 
+    ${c_yellow}BRAKER params:${c_reset}
+    ${c_dim}--run_braker${c_reset}                Whether to use BRAKER for gene prediction. [default: $params.run_braker]
+
     ${c_yellow}Skipping options:${c_reset}
     ${c_dim}--skip_rename${c_reset}               Skip renaming genome fasta file by funannotate sort. [default: $params.skip_rename]
     ${c_dim}--skip_all_masking${c_reset}          Skip all masking processes, please be sure that your --genome input is soft-masked before triggering this parameter. [default: $params.skip_all_masking]

--- a/annotation/nextflow/modules/local/braker/Braker.nf
+++ b/annotation/nextflow/modules/local/braker/Braker.nf
@@ -11,9 +11,10 @@ process GENE_PREDICTION_BRAKER {
 	val(rna_bam)
 
 	output:
-	path("braker/*")         , emit: output
-	path("braker/braker.aa") , emit: protseq
-	path "versions.yml"    , emit: versions
+	path("braker/*")          , emit: output
+	path("braker/braker.aa")  , emit: protseq
+	path("braker/braker.gff3"), emit: gff
+	path "versions.yml"       , emit: versions
 
 	script:
     def args_fungus = params.organism == "fungus" ? "--fungus" : ""

--- a/annotation/nextflow/modules/local/funannotate/FunannotatePredict.nf
+++ b/annotation/nextflow/modules/local/funannotate/FunannotatePredict.nf
@@ -1,5 +1,6 @@
 process GENE_PREDICTION_FUNANNOTATE {
 	label 'process_high'
+	label 'process_high_memory'
 	label 'funannotate'
 
 	containerOptions = "--bind /env:/env --bind ${params.tmpdir}:/opt/databases --bind /mnt:/mnt"
@@ -14,6 +15,7 @@ process GENE_PREDICTION_FUNANNOTATE {
 	output:
 	path("output")                              , emit: output
 	path("output/predict_results/*.proteins.fa"), emit: protseq
+	path("output/predict_results/*.gff3")       , emit: gff
 	path "versions.yml"                         , emit: versions
 
 	script:
@@ -22,6 +24,7 @@ process GENE_PREDICTION_FUNANNOTATE {
 	def args_stringtie = stringtie != "EMPTY" ? "--stringtie ${stringtie}" : ""
     def args_buscodb = params.buscodb ? "--busco_db '${params.buscodb}'" : ""
 	def args_buscoseed = params.buscoseed == null ? "" : "--busco_seed_species '${params.buscoseed}'"
+	def args_ploidy = params.ploidy ? "--ploidy ${params.ploidy}" : ""
 
 	"""
 	augustus_species=\$(echo ${species} | sed 's/ /_/g')
@@ -37,7 +40,8 @@ process GENE_PREDICTION_FUNANNOTATE {
 	${args_buscoseed} \\
 	${args_prot} \\
 	${args_rna} \\
-	${args_stringtie}
+	${args_stringtie} \\
+	${args_ploidy}
 
 	cat <<-VERSIONS > versions.yml
 	"${task.process}":

--- a/annotation/nextflow/modules/local/utils/RenameGff.nf
+++ b/annotation/nextflow/modules/local/utils/RenameGff.nf
@@ -1,0 +1,24 @@
+process RENAMEGFF {
+	label 'process_low'
+    label 'process_single'
+	label 'tools'
+
+	input:
+	file(lookup)
+	file(inGff)   
+	
+	output:
+	path("renamed_output.gff"), emit: outGff
+	path "versions.yml"       , emit: versions
+
+	script:
+	"""
+	python ${projectDir}/bin/rename_gff.py -l ${lookup} -i ${inGff} -o renamed_output.gff
+
+	cat <<-VERSIONS > versions.yml
+	"${task.process}":
+		python: 3.11.6
+	    pandas: 2.1.3
+	VERSIONS
+	"""
+}

--- a/annotation/nextflow/nextflow.config
+++ b/annotation/nextflow/nextflow.config
@@ -81,6 +81,7 @@ profiles {
 	conda {
         conda.enabled          = true
 		conda.cacheDir         = params.condaCacheDir
+		conda.createTimeout    = '1 h'
 		singularity.enabled    = true // for BRAKER
 		apptainer.enabled      = false
         docker.enabled         = false
@@ -89,6 +90,7 @@ profiles {
 	mamba {
 		conda.enabled          = true
 		conda.useMamba         = true
+		conda.createTimeout    = '1 h'
 		conda.cacheDir         = params.condaCacheDir
 		singularity.enabled    = true // for BRAKER
 		apptainer.enabled      = false


### PR DESCRIPTION
- Python script to analyze the number of exons per transcript (let it mRNA or tRNA), generate the number of mono exons, multi exons, mono/multi ratio, etc.
- Adding a step in the workflow to rename the output GFF file's contigs back to the original name, now saved as `rename_output.gff`, which can be compared with other GFF.
- Modify README.md, adding TOC and more detailed information about the workflow.