### PR TITLE
Fix bug in RepeatMasker.nf when genome is less than 10Mb

### DIFF
--- a/annotation/nextflow/modules/local/repeatmasker/RepeatMasker.nf
+++ b/annotation/nextflow/modules/local/repeatmasker/RepeatMasker.nf
@@ -26,6 +26,9 @@ process REPEATMASKER {
 	#Rename fasta header to only contain the first element
 	awk '/^>/ {sub(/ .*/, ""); printf("%s\\n", \$0); next;} {print;}' genome.fasta.masked > genome.fasta.masked.clean
 
+	#Compress cat when not already compressed
+        [ -f genome.fasta.cat.gz ] || gzip genome.fasta.cat
+
 	cat <<-VERSIONS > versions.yml
 	"${task.process}":
 	    RepeatMasker:  \$( RepeatMasker -v | sed -e "s/RepeatMasker version //g")


### PR DESCRIPTION
RepeatMasker by default will not gzip the output genome.cat, but annotato pipeline expects for the genome.cat.gz

From RepeatMasker.pl

```
my $compressCatFile = 1 if ( $totseqlen > 10000000 );
```